### PR TITLE
Add restore_mode support to power switch

### DIFF
--- a/components/matrix_display_switch/matrix_display_switch.cpp
+++ b/components/matrix_display_switch/matrix_display_switch.cpp
@@ -2,6 +2,13 @@
 
 namespace esphome::matrix_display::matrix_display_switch
 {
+    void MatrixDisplaySwitch::setup()
+    {
+        auto initial_state = this->get_initial_state_with_restore_mode().value_or(false);
+        ESP_LOGD(TAG, "Setting up matrix display switch with initial state: %i", initial_state);
+        write_state(initial_state);
+    }
+
     void MatrixDisplaySwitch::write_state(bool state)
     {
         // Update display status and forwad state to all registered power switches.

--- a/components/matrix_display_switch/matrix_display_switch.h
+++ b/components/matrix_display_switch/matrix_display_switch.h
@@ -16,6 +16,7 @@ namespace esphome::matrix_display::matrix_display_switch
          */
         void write_state(bool state);
 
+        void setup() override;
         void dump_config() override;
 
         /**


### PR DESCRIPTION
This pull request adds support for the 'restore_mode' clause on the power switch.

Close #5 