### PR TITLE
feat: added example config for adafruit matrix portal s3 device.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ display:
     height: 32
 ```
 
+An example config with the correct GPIO mappings for the Adafruit Matrix Portal S3 ESP32-S3 based board with HUB75 interface can be found [here](matrix-portal-s3-example.yaml). This configuration should also work for any ESP32-S3-WROOM MCU.
+
 The additional settings are used to set the configuration variables for the wrapped display library. For more information on how to use these and their purpose please refer to the library's [documentation](https://github.com/mrcodetastic/ESP32-HUB75-MatrixPanel-DMA/tree/master) and [examples](https://github.com/mrcodetastic/ESP32-HUB75-MatrixPanel-DMA/tree/master/examples).
 
 - **id**(**Required**, string): Matrix ID which will be used for entity configuration.

--- a/matrix-portal-s3-example.yaml
+++ b/matrix-portal-s3-example.yaml
@@ -1,0 +1,52 @@
+esphome:
+  name: matrix-display
+  friendly_name: Matrix Display
+
+external_components:
+  - source: github://TillFleisch/ESPHome-HUB75-MatrixDisplayWrapper@main
+
+esp32:
+  board: esp32-s3-devkitc-1
+  framework:
+    type: arduino
+
+font:
+  # gfonts://family[@weight]
+  - file: "gfonts://Roboto"
+    id: roboto
+    size: 10
+
+display:
+  - platform: hub75_matrix_display
+    id: matrix
+    width: 64
+    height: 32
+    R1_pin: 42
+    G1_pin: 41
+    B1_pin: 40
+    R2_pin: 38
+    G2_pin: 39
+    B2_pin: 37
+    A_pin: 45
+    B_pin: 36
+    C_pin: 48
+    D_pin: 35
+    E_pin: 21
+    LAT_pin: 47
+    OE_pin: 14
+    CLK_pin: 2
+
+    lambda: |-
+      it.print(0, 0, id(roboto), "Hello World!");
+
+switch:
+  - platform: hub75_matrix_display
+    matrix_id: matrix
+    name: "Power"
+    restore_mode: ALWAYS_ON
+    id: power
+
+number:
+  - platform: hub75_matrix_display
+    matrix_id: matrix
+    name: "Brightness"


### PR DESCRIPTION
Added working configuration example for the adafruit matrix portal s3 device (ESP32-S3-WROOM board with integrated HUB75 interface etc) and probably any other board that uses that MCU.