### PR TITLE
Update enumerations

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ The additional settings are used to set the configuration variables for the wrap
 - **OE_pin**(**Optional**, [Pin](https://esphome.io/guides/configuration-types.html#config-pin)): Pin connected to the OE pin on the matrix display. Defaults to `15`.
 - **CLK_pin**(**Optional**, [Pin](https://esphome.io/guides/configuration-types.html#config-pin)): Pin connected to the CLK pin on the matrix display. Defaults to `16`.
 
-- **driver**(**Optional**): Driver used for configuring the display. Select one of `SHIFTREG`, `FM6124`, `FM6126A`, `ICN2038S`, `MBI5124`, `SM5266`.
-- **i2sspeed**(**Optional**): I2SSpeed used for configuring the display. Select one of `HZ_8M`, `HZ_10M`, `HZ_15M`, `HZ_20M`.
+- **driver**(**Optional**): Driver used for configuring the display. Select one of `SHIFTREG`, `FM6124`, `FM6126A`, `ICN2038S`, `MBI5124`, `SM5266`, `DP3246_SM5368`.
+- **i2sspeed**(**Optional**): I2SSpeed used for configuring the display. Select one of `HZ_8M`, `HZ_10M`, `HZ_15M`, `HZ_16M`,`HZ_20M`.
 - **latch_blanking**(**Optional**, int): Latch blanking value used for configuring the display.
 - **clock_phase**(**Optional**, boolean): Clock phase value used for configuring the display.
 - **use_custom_library**(**Optional**, boolean): If set to `true` a custom library must be defined using `platformio_options:lib_deps`. Defaults to `false`. See [this example](custom_library.yaml) for more details.

--- a/components/hub75_matrix_display/display.py
+++ b/components/hub75_matrix_display/display.py
@@ -53,6 +53,7 @@ DRIVERS = {
     "ICN2038S": shift_driver.ICN2038S,
     "MBI5124": shift_driver.MBI5124,
     "SM5266": shift_driver.SM5266P,
+    "DP3246_SM5368": shift_driver.DP3246_SM5368,
 }
 
 clk_speed = cg.global_ns.namespace("HUB75_I2S_CFG").enum("clk_speed")

--- a/components/hub75_matrix_display/display.py
+++ b/components/hub75_matrix_display/display.py
@@ -61,6 +61,7 @@ CLOCK_SPEEDS = {
     "HZ_8M": clk_speed.HZ_8M,
     "HZ_10M": clk_speed.HZ_10M,
     "HZ_15M": clk_speed.HZ_15M,
+    "HZ_16M": clk_speed.HZ_16M,
     "HZ_20M": clk_speed.HZ_20M,
 }
 

--- a/components/hub75_matrix_display/matrix_display.cpp
+++ b/components/hub75_matrix_display/matrix_display.cpp
@@ -72,9 +72,9 @@ namespace esphome
             HUB75_I2S_CFG cfg = this->dma_display_->getCfg();
 
             // Log pin settings
-            ESP_LOGCONFIG(TAG, "  Pins: R1:%i, G1:%i, B1:%i, R2:%i, G2:%i, B2:%i", cfg.i2s_pins.r1, cfg.i2s_pins.g1, cfg.i2s_pins.b1, cfg.i2s_pins.r2, cfg.i2s_pins.g2, cfg.i2s_pins.b2);
-            ESP_LOGCONFIG(TAG, "  Pins: A:%i, B:%i, C:%i, D:%i, E:%i", cfg.i2s_pins.a, cfg.i2s_pins.b, cfg.i2s_pins.c, cfg.i2s_pins.d, cfg.i2s_pins.e);
-            ESP_LOGCONFIG(TAG, "  Pins: LAT:%i, OE:%i, CLK:%i", cfg.i2s_pins.lat, cfg.i2s_pins.oe, cfg.i2s_pins.clk);
+            ESP_LOGCONFIG(TAG, "  Pins: R1:%i, G1:%i, B1:%i, R2:%i, G2:%i, B2:%i", cfg.gpio.r1, cfg.gpio.g1, cfg.gpio.b1, cfg.gpio.r2, cfg.gpio.g2, cfg.gpio.b2);
+            ESP_LOGCONFIG(TAG, "  Pins: A:%i, B:%i, C:%i, D:%i, E:%i", cfg.gpio.a, cfg.gpio.b, cfg.gpio.c, cfg.gpio.d, cfg.gpio.e);
+            ESP_LOGCONFIG(TAG, "  Pins: LAT:%i, OE:%i, CLK:%i", cfg.gpio.lat, cfg.gpio.oe, cfg.gpio.clk);
 
             // Log driver settings
             switch (cfg.driver)

--- a/components/hub75_matrix_display/matrix_display.cpp
+++ b/components/hub75_matrix_display/matrix_display.cpp
@@ -69,44 +69,43 @@ namespace esphome
         {
             ESP_LOGCONFIG(TAG, "MatrixDisplay:");
 
+            HUB75_I2S_CFG cfg = this->dma_display_->getCfg();
+
             // Log pin settings
-            ESP_LOGCONFIG(TAG, "Pins: R1:%i, G1:%i, B1:%i, R2:%i, G2:%i, B2:%i", pins_.r1, pins_.g1, pins_.b1, pins_.r2, pins_.g2, pins_.b2);
-            ESP_LOGCONFIG(TAG, "Pins: A:%i, B:%i, C:%i, D:%i, E:%i", pins_.a, pins_.b, pins_.c, pins_.d, pins_.e);
-            ESP_LOGCONFIG(TAG, "Pins: LAT:%i, OE:%i, CLK:%i", pins_.lat, pins_.oe, pins_.b1, pins_.clk);
+            ESP_LOGCONFIG(TAG, "  Pins: R1:%i, G1:%i, B1:%i, R2:%i, G2:%i, B2:%i", cfg.i2s_pins.r1, cfg.i2s_pins.g1, cfg.i2s_pins.b1, cfg.i2s_pins.r2, cfg.i2s_pins.g2, cfg.i2s_pins.b2);
+            ESP_LOGCONFIG(TAG, "  Pins: A:%i, B:%i, C:%i, D:%i, E:%i", cfg.i2s_pins.a, cfg.i2s_pins.b, cfg.i2s_pins.c, cfg.i2s_pins.d, cfg.i2s_pins.e);
+            ESP_LOGCONFIG(TAG, "  Pins: LAT:%i, OE:%i, CLK:%i", cfg.i2s_pins.lat, cfg.i2s_pins.oe, cfg.i2s_pins.clk);
 
             // Log driver settings
-            switch (dma_display_->getCfg().driver)
+            switch (cfg.driver)
             {
             case HUB75_I2S_CFG::shift_driver::SHIFTREG:
-                ESP_LOGCONFIG(TAG, "Driver: SHIFTREG");
+                ESP_LOGCONFIG(TAG, "  Driver: SHIFTREG");
                 break;
             case HUB75_I2S_CFG::shift_driver::FM6124:
-                ESP_LOGCONFIG(TAG, "Driver: FM6124");
+                ESP_LOGCONFIG(TAG, "  Driver: FM6124");
                 break;
             case HUB75_I2S_CFG::shift_driver::FM6126A:
-                ESP_LOGCONFIG(TAG, "Driver: FM6126A");
+                ESP_LOGCONFIG(TAG, "  Driver: FM6126A");
                 break;
             case HUB75_I2S_CFG::shift_driver::ICN2038S:
-                ESP_LOGCONFIG(TAG, "Driver: ICN2038S");
+                ESP_LOGCONFIG(TAG, "  Driver: ICN2038S");
                 break;
             case HUB75_I2S_CFG::shift_driver::MBI5124:
-                ESP_LOGCONFIG(TAG, "Driver: MBI5124");
+                ESP_LOGCONFIG(TAG, "  Driver: MBI5124");
                 break;
             case HUB75_I2S_CFG::shift_driver::SM5266P:
-                ESP_LOGCONFIG(TAG, "Driver: SM5266P");
+                ESP_LOGCONFIG(TAG, "  Driver: SM5266P");
                 break;
             case HUB75_I2S_CFG::shift_driver::DP3246_SM5368:
-                ESP_LOGCONFIG(TAG, "Driver: DP3246_SM5368");
+                ESP_LOGCONFIG(TAG, "  Driver: DP3246_SM5368");
                 break;
             }
 
-            ESP_LOGCONFIG(TAG, "I2S Speed: %u MHz", (uint32_t)this->dma_display_->getCfg().i2sspeed / 1000000);
-
-            ESP_LOGCONFIG(TAG, "Latch blanking: %i", dma_display_->getCfg().latch_blanking);
-
-            ESP_LOGCONFIG(TAG, "Clock Phase: %s", dma_display_->getCfg().clkphase ? "true" : "false");
-
-            ESP_LOGCONFIG(TAG, "Min refresh rate: %i", dma_display_->getCfg().min_refresh_rate);
+            ESP_LOGCONFIG(TAG, "  I2S Speed: %u MHz", (uint32_t)cfg.i2sspeed / 1000000);
+            ESP_LOGCONFIG(TAG, "  Latch Blanking: %i", cfg.latch_blanking);
+            ESP_LOGCONFIG(TAG, "  Clock Phase: %s", TRUEFALSE(cfg.clkphase));
+            ESP_LOGCONFIG(TAG, "  Min Refresh Rate: %i", cfg.min_refresh_rate);
         }
 
         void MatrixDisplay::set_state(bool state)

--- a/components/hub75_matrix_display/matrix_display.cpp
+++ b/components/hub75_matrix_display/matrix_display.cpp
@@ -100,22 +100,7 @@ namespace esphome
                 break;
             }
 
-            // Log i2speed
-            switch (dma_display_->getCfg().i2sspeed)
-            {
-            case HUB75_I2S_CFG::clk_speed::HZ_8M:
-                ESP_LOGCONFIG(TAG, "I2SSpeed: HZ_8M");
-                break;
-            case HUB75_I2S_CFG::clk_speed::HZ_10M:
-                ESP_LOGCONFIG(TAG, "I2SSpeed: HZ_10M");
-                break;
-            case HUB75_I2S_CFG::clk_speed::HZ_15M:
-                ESP_LOGCONFIG(TAG, "I2SSpeed: HZ_15M");
-                break;
-            case HUB75_I2S_CFG::clk_speed::HZ_20M:
-                ESP_LOGCONFIG(TAG, "I2SSpeed: HZ_20M");
-                break;
-            }
+            ESP_LOGCONFIG(TAG, "I2S Speed: %u MHz", (uint32_t)this->dma_display_->getCfg().i2sspeed / 1000000);
 
             ESP_LOGCONFIG(TAG, "Latch blanking: %i", dma_display_->getCfg().latch_blanking);
 

--- a/components/hub75_matrix_display/matrix_display.cpp
+++ b/components/hub75_matrix_display/matrix_display.cpp
@@ -95,6 +95,9 @@ namespace esphome
             case HUB75_I2S_CFG::shift_driver::SM5266P:
                 ESP_LOGCONFIG(TAG, "Driver: SM5266P");
                 break;
+            case HUB75_I2S_CFG::shift_driver::DP3246_SM5368:
+                ESP_LOGCONFIG(TAG, "Driver: DP3246_SM5368");
+                break;
             }
 
             // Log i2speed


### PR DESCRIPTION
This PR adds missing values to the shift driver and clock speed enumerations and fixes the dump_config() function to allow using the wrapper with the latest version of the ESP32-HUB75-MatrixPanel-DMA library.

- Add DP3246_SM5368 shift driver
- Add HZ_16M clock speed
- Fix and clean up dump_config() output
  - Use live configuration for pin listing
  - Fix CLK pin showing pin B1 instead
  - Show I2S speed in MHz instead of the enumeration member name due to duplicated enumeration values in the library (HZ_8M == HZ_10M and HZ_15M == HZ_16M)


Close #26 