### PR TITLE
Use latest official library by default and build without GFX library

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ The additional settings are used to set the configuration variables for the wrap
 - **OE_pin**(**Optional**, [Pin](https://esphome.io/guides/configuration-types.html#config-pin)): Pin connected to the OE pin on the matrix display. Defaults to `15`.
 - **CLK_pin**(**Optional**, [Pin](https://esphome.io/guides/configuration-types.html#config-pin)): Pin connected to the CLK pin on the matrix display. Defaults to `16`.
 
-- **driver**(**Optional**): Driver used for configuring the display. Select one of `SHIFTREG`, `FM6124`, `FM6126A`, `ICN2038S`, `MBI5124`, `SM5266`, `DP3246_SM5368`.
+- **driver**(**Optional**): Driver used for configuring the display. Select one of `SHIFTREG`, `FM6124`, `FM6126A`, `ICN2038S`, `MBI5124`, `DP3246`.
+- **line_decoder**(**Optional**): Line decoder used for configuring the display. Select one of `TYPE138`, `TYPE595`, `TYPE_DIRECT`, `SM5266P`, `SM5368`.
 - **i2sspeed**(**Optional**): I2SSpeed used for configuring the display. Select one of `HZ_8M`, `HZ_10M`, `HZ_15M`, `HZ_16M`,`HZ_20M`.
 - **latch_blanking**(**Optional**, int): Latch blanking value used for configuring the display.
 - **clock_phase**(**Optional**, boolean): Clock phase value used for configuring the display.

--- a/components/hub75_matrix_display/display.py
+++ b/components/hub75_matrix_display/display.py
@@ -100,12 +100,9 @@ CONFIG_SCHEMA = display.FULL_DISPLAY_SCHEMA.extend(
 
 async def to_code(config):
     if not config[USE_CUSTOM_LIBRARY]:
-        cg.add_library("SPI", None)
-        cg.add_library("Wire", None)
-        cg.add_library("Adafruit BusIO", None)
-        cg.add_library("adafruit/Adafruit GFX Library", None)
+        cg.add_build_flag("-DNO_GFX=1")
         cg.add_library(
-            "https://github.com/TillFleisch/ESP32-HUB75-MatrixPanel-DMA#optional_logging",
+            "https://github.com/mrcodetastic/ESP32-HUB75-MatrixPanel-DMA",
             None,
         )
 

--- a/components/hub75_matrix_display/display.py
+++ b/components/hub75_matrix_display/display.py
@@ -34,6 +34,7 @@ OE_PIN = "OE_pin"
 CLK_PIN = "CLK_pin"
 
 DRIVER = "driver"
+LINE_DECODER = "line_decoder"
 I2SSPEED = "i2sspeed"
 LATCH_BLANKING = "latch_blanking"
 CLOCK_PHASE = "clock_phase"
@@ -46,14 +47,22 @@ MatrixDisplay = matrix_display_ns.class_(
 )
 
 shift_driver = cg.global_ns.namespace("HUB75_I2S_CFG").enum("shift_driver")
-DRIVERS = {
+SHIFT_DRIVERS = {
     "SHIFTREG": shift_driver.SHIFTREG,
     "FM6124": shift_driver.FM6124,
     "FM6126A": shift_driver.FM6126A,
     "ICN2038S": shift_driver.ICN2038S,
     "MBI5124": shift_driver.MBI5124,
-    "SM5266": shift_driver.SM5266P,
-    "DP3246_SM5368": shift_driver.DP3246_SM5368,
+    "DP3246": shift_driver.DP3246,
+}
+
+line_driver = cg.global_ns.namespace("HUB75_I2S_CFG").enum("line_driver")
+LINE_DRIVERS = {
+    "TYPE138": line_driver.TYPE138,
+    "TYPE595": line_driver.TYPE595,
+    "TYPE_DIRECT": line_driver.TYPE_DIRECT,
+    "SM5266P": line_driver.SM5266P,
+    "SM5368": line_driver.SM5368,
 }
 
 clk_speed = cg.global_ns.namespace("HUB75_I2S_CFG").enum("clk_speed")
@@ -90,7 +99,8 @@ CONFIG_SCHEMA = display.FULL_DISPLAY_SCHEMA.extend(
         cv.Optional(LAT_PIN, default=4): pins.gpio_output_pin_schema,
         cv.Optional(OE_PIN, default=15): pins.gpio_output_pin_schema,
         cv.Optional(CLK_PIN, default=16): pins.gpio_output_pin_schema,
-        cv.Optional(DRIVER): cv.enum(DRIVERS, upper=True, space="_"),
+        cv.Optional(DRIVER): cv.enum(SHIFT_DRIVERS, upper=True, space="_"),
+        cv.Optional(LINE_DECODER): cv.enum(LINE_DRIVERS, upper=True, space="_"),
         cv.Optional(I2SSPEED): cv.enum(CLOCK_SPEEDS, upper=True, space="_"),
         cv.Optional(LATCH_BLANKING): cv.positive_int,
         cv.Optional(CLOCK_PHASE): cv.boolean,
@@ -153,7 +163,10 @@ async def to_code(config):
     )
 
     if DRIVER in config:
-        cg.add(var.set_driver(config[DRIVER]))
+        cg.add(var.set_shift_driver(config[DRIVER]))
+
+    if LINE_DECODER in config:
+        cg.add(var.set_line_decoder(config[LINE_DECODER]))
 
     if I2SSPEED in config:
         cg.add(var.set_i2sspeed(config[I2SSPEED]))

--- a/components/hub75_matrix_display/matrix_display.cpp
+++ b/components/hub75_matrix_display/matrix_display.cpp
@@ -76,11 +76,25 @@ namespace esphome
             case HUB75_I2S_CFG::shift_driver::MBI5124:
                 ESP_LOGCONFIG(TAG, "  Driver: MBI5124");
                 break;
-            case HUB75_I2S_CFG::shift_driver::SM5266P:
-                ESP_LOGCONFIG(TAG, "  Driver: SM5266P");
+            case HUB75_I2S_CFG::shift_driver::DP3246:
+                ESP_LOGCONFIG(TAG, "  Driver: DP3246");
                 break;
-            case HUB75_I2S_CFG::shift_driver::DP3246_SM5368:
-                ESP_LOGCONFIG(TAG, "  Driver: DP3246_SM5368");
+            }
+
+            // Log line_decoder
+            switch (cfg.line_decoder)
+            {
+            case HUB75_I2S_CFG::line_driver::TYPE138:
+                ESP_LOGCONFIG(TAG, "  Driver: TYPE138");
+                break;
+            case HUB75_I2S_CFG::line_driver::TYPE595: // SM5368 is an alias for TYPE595
+                ESP_LOGCONFIG(TAG, "  Driver: TYPE595 | SM5368");
+                break;
+            case HUB75_I2S_CFG::line_driver::TYPE_DIRECT:
+                ESP_LOGCONFIG(TAG, "  Driver: TYPE_DIRECT");
+                break;
+            case HUB75_I2S_CFG::line_driver::SM5266P:
+                ESP_LOGCONFIG(TAG, "  Driver: SM5266P");
                 break;
             }
 

--- a/components/hub75_matrix_display/matrix_display.h
+++ b/components/hub75_matrix_display/matrix_display.h
@@ -125,13 +125,23 @@ namespace esphome
             }
 
             /**
-             * Sets the driver which will be used before display instantiation.
+             * Sets the shift driver which will be used before display instantiation.
              *
-             * @param driver Driver enum
+             * @param shift_driver Shift driver enum
              */
-            void set_driver(HUB75_I2S_CFG::shift_driver driver)
+            void set_shift_driver(HUB75_I2S_CFG::shift_driver shift_driver)
             {
-                this->mxconfig_.driver = driver;
+                this->mxconfig_.driver = shift_driver;
+            };
+
+            /**
+             * Sets the line driver which will be used before display instantiation.
+             *
+             * @param line_decoder line driver enum
+             */
+            void set_line_decoder(HUB75_I2S_CFG::line_driver line_decoder)
+            {
+                this->mxconfig_.line_decoder = line_decoder;
             };
 
             /**


### PR DESCRIPTION
As ESPHome has its own drawing functions, there is no need to include the Adafruit GFX Library and its dependencies (the compiler would likely optimize them out anyway).
This sets the `NO_GFX` build option and pulls in the official library, that can now be used after #25 has been merged.

I know that this re-enables the logging that you removed from your own branch, but I don't mind that too much as it mainly logs during setup and could be disabled using the normal ESPHome `logger` configuration.