### PR TITLE
Align logging tag scheme with ESPHome core components

### DIFF
--- a/components/hub75_matrix_display/matrix_display.cpp
+++ b/components/hub75_matrix_display/matrix_display.cpp
@@ -5,7 +5,7 @@ namespace esphome
     namespace matrix_display
     {
 
-        static const char *const TAG = "MatrixDisplay";
+        static const char *const TAG = "matrix_display";
 
         /**
          * Initialize the wrapped matrix display with user parameters

--- a/components/hub75_matrix_display/number/matrix_display_brightness.h
+++ b/components/hub75_matrix_display/number/matrix_display_brightness.h
@@ -6,7 +6,7 @@
 
 namespace esphome::matrix_display::matrix_display_brightness
 {
-    static const char *TAG = "MatrixDisplayBrightness";
+    static const char *TAG = "matrix_display.number";
     class MatrixDisplayBrightness : public number::Number, public Component
     {
     public:

--- a/components/hub75_matrix_display/switch/matrix_display_switch.h
+++ b/components/hub75_matrix_display/switch/matrix_display_switch.h
@@ -6,7 +6,7 @@
 
 namespace esphome::matrix_display::matrix_display_switch
 {
-    static const char *TAG = "MatrixDisplaySwitch";
+    static const char *TAG = "matrix_display.switch";
 
     class MatrixDisplaySwitch : public switch_::Switch, public Component
     {


### PR DESCRIPTION
Just a very small change that aligns the logging tags with how ESPHome core components use them.