### PR TITLE
Fix switch.SWITCH_SCHEMA deprecation

### DIFF
--- a/components/hub75_matrix_display/switch/__init__.py
+++ b/components/hub75_matrix_display/switch/__init__.py
@@ -12,9 +12,8 @@ MatrixDisplaySwitch = matrix_display_switch_ns.class_(
     "MatrixDisplaySwitch", switch.Switch, cg.Component
 )
 
-CONFIG_SCHEMA = switch.SWITCH_SCHEMA.extend(
+CONFIG_SCHEMA = switch.switch_schema(MatrixDisplaySwitch).extend(
     {
-        cv.GenerateID(): cv.declare_id(MatrixDisplaySwitch),
         cv.Required(MATRIX_ID): cv.use_id(MatrixDisplay),
     }
 ).extend(cv.COMPONENT_SCHEMA)


### PR DESCRIPTION
Replace deprecated switch.SWITCH_SCHEMA with switch.switch_schema() function to align with ESPHome 2025.11.0 breaking changes. This change:

- Uses switch.switch_schema(MatrixDisplaySwitch) instead of SWITCH_SCHEMA
- Removes redundant cv.GenerateID() declaration (handled by switch_schema)
- Maintains backward compatibility until ESPHome 2025.11.0
- Follows ESPHome's new schema pattern guidelines

Fixed using AI (Augment Code)