### PR TITLE
LVGL support + non-horizontal panel layouts

### DIFF
--- a/components/hub75_matrix_display/display.py
+++ b/components/hub75_matrix_display/display.py
@@ -100,12 +100,9 @@ CONFIG_SCHEMA = display.FULL_DISPLAY_SCHEMA.extend(
 
 async def to_code(config):
     if not config[USE_CUSTOM_LIBRARY]:
-        cg.add_library("SPI", None)
-        cg.add_library("Wire", None)
-        cg.add_library("Adafruit BusIO", None)
-        cg.add_library("adafruit/Adafruit GFX Library", None)
+        cg.add_build_flag("-DNO_GFX=1")
         cg.add_library(
-            "https://github.com/TillFleisch/ESP32-HUB75-MatrixPanel-DMA#optional_logging",
+            "https://github.com/mrcodetastic/ESP32-HUB75-MatrixPanel-DMA",
             None,
         )
 

--- a/components/hub75_matrix_display/display.py
+++ b/components/hub75_matrix_display/display.py
@@ -37,6 +37,7 @@ DRIVER = "driver"
 I2SSPEED = "i2sspeed"
 LATCH_BLANKING = "latch_blanking"
 CLOCK_PHASE = "clock_phase"
+DOUBLE_BUFFER = "double_buffer"
 
 USE_CUSTOM_LIBRARY = "use_custom_library"
 
@@ -70,12 +71,10 @@ CONFIG_SCHEMA = display.FULL_DISPLAY_SCHEMA.extend(
         cv.GenerateID(): cv.declare_id(MatrixDisplay),
         cv.Required(CONF_WIDTH): cv.positive_int,
         cv.Required(CONF_HEIGHT): cv.positive_int,
+        cv.Required(DOUBLE_BUFFER): cv.boolean,
         cv.Optional(USE_CUSTOM_LIBRARY, default=False): cv.boolean,
         cv.Optional(CHAIN_LENGTH, default=1): cv.positive_int,
         cv.Optional(BRIGHTNESS, default=128): cv.int_range(min=0, max=255),
-        cv.Optional(
-            CONF_UPDATE_INTERVAL, default="16ms"
-        ): cv.positive_time_period_milliseconds,
         cv.Optional(R1_PIN, default=25): pins.gpio_output_pin_schema,
         cv.Optional(G1_PIN, default=26): pins.gpio_output_pin_schema,
         cv.Optional(B1_PIN, default=27): pins.gpio_output_pin_schema,

--- a/components/hub75_matrix_display/display.py
+++ b/components/hub75_matrix_display/display.py
@@ -41,6 +41,61 @@ DOUBLE_BUFFER = "double_buffer"
 
 USE_CUSTOM_LIBRARY = "use_custom_library"
 
+VIRTUAL_MATRIX = "virtual_matrix"
+VM_ENABLED = "enabled"
+VM_ROWS = "rows"
+VM_COLS = "cols"
+VM_CHAIN_TYPE = "chain_type"
+VM_SCAN_TYPE = "scan_type"
+
+# Accepted values map to ESP32-HUB75-VirtualMatrixPanel_T.hpp enums.
+VM_CHAIN_CHOICES = cv.one_of(
+    "CHAIN_TOP_LEFT_DOWN",
+    "CHAIN_TOP_RIGHT_DOWN",
+    "CHAIN_BOTTOM_LEFT_UP",
+    "CHAIN_BOTTOM_RIGHT_UP",
+    "CHAIN_TOP_LEFT_DOWN_ZZ",
+    "CHAIN_TOP_RIGHT_DOWN_ZZ",
+    "CHAIN_BOTTOM_LEFT_UP_ZZ",
+    "CHAIN_BOTTOM_RIGHT_UP_ZZ",
+    upper=True,
+)
+
+VM_SCAN_CHOICES = cv.one_of(
+    "STANDARD_TWO_SCAN",
+    "FOUR_SCAN_16PX_HIGH",
+    "FOUR_SCAN_32PX_HIGH",
+    "FOUR_SCAN_40PX_HIGH",
+    "FOUR_SCAN_40_80PX_HFARCAN",
+    "FOUR_SCAN_64PX_HIGH",
+    upper=True,
+)
+
+VIRTUAL_MATRIX_SCHEMA = cv.Schema(
+    {
+        cv.Required(VM_ENABLED): cv.boolean,
+        cv.Optional(VM_ROWS, default=1): cv.positive_int,
+        cv.Optional(VM_COLS, default=1): cv.positive_int,
+        cv.Optional(VM_CHAIN_TYPE, default="CHAIN_TOP_LEFT_DOWN"): VM_CHAIN_CHOICES,
+        cv.Optional(VM_SCAN_TYPE, default="STANDARD_TWO_SCAN"): VM_SCAN_CHOICES,
+    }
+)
+
+def _validate_virtual_matrix(config):
+    # Enforce chain_length == rows*cols when virtual matrix mapping is enabled.
+    vm = config.get(VIRTUAL_MATRIX)
+    if vm and vm.get(VM_ENABLED, False):
+        rows = vm.get(VM_ROWS, 1)
+        cols = vm.get(VM_COLS, 1)
+        required = rows * cols
+        chain_len = config.get(CHAIN_LENGTH, 1)
+        if chain_len != required:
+            raise cv.Invalid(
+                f"When virtual_matrix.enabled is true, chain_length must equal rows*cols "
+                f"({rows}*{cols}={required}), but chain_length is {chain_len}."
+            )
+    return config
+
 matrix_display_ns = cg.esphome_ns.namespace("matrix_display")
 MatrixDisplay = matrix_display_ns.class_(
     "MatrixDisplay", cg.PollingComponent, display.DisplayBuffer
@@ -93,8 +148,11 @@ CONFIG_SCHEMA = display.FULL_DISPLAY_SCHEMA.extend(
         cv.Optional(I2SSPEED): cv.enum(CLOCK_SPEEDS, upper=True, space="_"),
         cv.Optional(LATCH_BLANKING): cv.positive_int,
         cv.Optional(CLOCK_PHASE): cv.boolean,
+        cv.Optional(VIRTUAL_MATRIX): VIRTUAL_MATRIX_SCHEMA,
     }
 )
+# Post-parse validation (enforce relationships between fields)
+CONFIG_SCHEMA = cv.All(CONFIG_SCHEMA, _validate_virtual_matrix)
 
 
 async def to_code(config):
@@ -162,6 +220,17 @@ async def to_code(config):
 
     if CLOCK_PHASE in config:
         cg.add(var.set_clock_phase(config[CLOCK_PHASE]))
+
+    vm = config.get(VIRTUAL_MATRIX)
+    if vm and vm[VM_ENABLED]:
+        cg.add_build_flag("-DUSE_VIRTUAL_PANEL=1")
+        cg.add_build_flag(f"-DVPANEL_CHAIN={vm[VM_CHAIN_TYPE]}")
+        cg.add_build_flag(f"-DVPANEL_SCAN={vm[VM_SCAN_TYPE]}")
+        cg.add(var.set_virtual_enabled(True))
+        cg.add(var.set_virtual_rows(vm[VM_ROWS]))
+        cg.add(var.set_virtual_cols(vm[VM_COLS]))
+    else:
+        cg.add(var.set_virtual_enabled(False))
 
     await display.register_display(var, config)
 

--- a/components/hub75_matrix_display/matrix_display.cpp
+++ b/components/hub75_matrix_display/matrix_display.cpp
@@ -29,6 +29,15 @@ namespace esphome
             this->stored_brightness_ = this->initial_brightness_;
             this->dma_display_->clearScreen();
 
+#ifdef USE_VIRTUAL_PANEL
+            if (this->use_virtual_panel_) {
+                // Wrap the physical DMA display with a virtual grid mapper
+                this->virtual_display_ = new VPanelType(this->v_rows_, this->v_cols_,
+                                                        this->mxconfig_.mx_width, this->mxconfig_.mx_height);
+                this->virtual_display_->setDisplay(*this->dma_display_);
+            }
+#endif
+
             // Default to off if power switches are present
             set_state(!this->power_switches_.size());
         }
@@ -87,6 +96,15 @@ namespace esphome
             ESP_LOGCONFIG(TAG, "  Latch Blanking: %i", cfg.latch_blanking);
             ESP_LOGCONFIG(TAG, "  Clock Phase: %s", TRUEFALSE(cfg.clkphase));
             ESP_LOGCONFIG(TAG, "  Min Refresh Rate: %i", cfg.min_refresh_rate);
+
+#ifdef USE_VIRTUAL_PANEL
+            ESP_LOGCONFIG(TAG, "  VirtualMatrix: %s", this->use_virtual_panel_ ? "ENABLED" : "disabled");
+            if (this->use_virtual_panel_) {
+                ESP_LOGCONFIG(TAG, "    Grid: %ux%u panels (total %u)",
+                              (unsigned)this->v_cols_, (unsigned)this->v_rows_,
+                              (unsigned)(this->v_cols_ * this->v_rows_));
+            }
+#endif
         }
 
         void MatrixDisplay::set_brightness(int brightness)
@@ -108,8 +126,8 @@ namespace esphome
             if (x >= this->get_width_internal() || x < 0 || y >= this->get_height_internal() || y < 0)
                 return;
 
-            // Update pixel value in buffer
-            this->dma_display_->drawPixelRGB888(x, y, color.r, color.g, color.b);
+            // Update pixel value in buffer (route via virtual when enabled)
+            this->draw_pixel_rgb888_(x, y, color.r, color.g, color.b);
         }
 
         inline uint8_t expand5to8(uint8_t v) { return (v << 3) | (v >> 2); }
@@ -142,19 +160,19 @@ namespace esphome
                         uint8_t g = expand6to8((pix565 >> 5)  & 0x3F);
                         uint8_t b = expand5to8( pix565        & 0x1F);
 
-                        this->dma_display_->drawPixelRGB888(x_start + xx, y_start + yy, r, g, b);
+                        this->draw_pixel_rgb888_(x_start + xx, y_start + yy, r, g, b);
                     }
                 } else { // 24-bit (RGB or BGR)
                     const uint8_t *src24 = ptr + row_base_px * 3;
                     if (order == ColorOrder::COLOR_ORDER_RGB) {
                         for (int xx = 0; xx < w; ++xx) {
                             const uint8_t *p = src24 + xx * 3;
-                            this->dma_display_->drawPixelRGB888(x_start + xx, y_start + yy, p[0], p[1], p[2]);
+                            this->draw_pixel_rgb888_(x_start + xx, y_start + yy, p[0], p[1], p[2]);
                         }
                     } else { // BGR
                         for (int xx = 0; xx < w; ++xx) {
                             const uint8_t *p = src24 + xx * 3;
-                            this->dma_display_->drawPixelRGB888(x_start + xx, y_start + yy, p[2], p[1], p[0]);
+                            this->draw_pixel_rgb888_(x_start + xx, y_start + yy, p[2], p[1], p[0]);
                         }
                     }
                 }
@@ -166,8 +184,8 @@ namespace esphome
             if (!this->dma_display_) return;
             if (!this->enabled_) return;
 
-            // Wrap fill screen method
-            this->dma_display_->fillScreenRGB888(color.r, color.g, color.b);
+            // Wrap fill screen method (route via virtual when enabled)
+            this->fill_screen_rgb888_(color.r, color.g, color.b);
         }
 
         void MatrixDisplay::filled_rectangle(int x1, int y1, int width, int height, Color color)
@@ -175,8 +193,19 @@ namespace esphome
             if (!this->dma_display_) return;
             if (!this->enabled_) return;
 
+#ifdef USE_VIRTUAL_PANEL
+            if (this->use_virtual_panel_) {
+                // Draw via per-pixel mapping when virtual wrapper is active
+                for (int yy = 0; yy < height; ++yy) {
+                    for (int xx = 0; xx < width; ++xx) {
+                        this->draw_pixel_rgb888_(x1 + xx, y1 + yy, color.r, color.g, color.b);
+                    }
+                }
+                return;
+            }
+#endif
             // Wrap fill rectangle method
-            this->dma_display_->fillRect(x1, y1, width, width, color.r, color.g, color.b);
+            this->dma_display_->fillRect(x1, y1, width, height, color.r, color.g, color.b);
         }
 
     } // namespace matrix_display

--- a/components/hub75_matrix_display/matrix_display.cpp
+++ b/components/hub75_matrix_display/matrix_display.cpp
@@ -76,11 +76,8 @@ namespace esphome
             case HUB75_I2S_CFG::shift_driver::MBI5124:
                 ESP_LOGCONFIG(TAG, "  Driver: MBI5124");
                 break;
-            case HUB75_I2S_CFG::shift_driver::SM5266P:
-                ESP_LOGCONFIG(TAG, "  Driver: SM5266P");
-                break;
-            case HUB75_I2S_CFG::shift_driver::DP3246_SM5368:
-                ESP_LOGCONFIG(TAG, "  Driver: DP3246_SM5368");
+            case HUB75_I2S_CFG::shift_driver::DP3246:
+                ESP_LOGCONFIG(TAG, "  Driver: DP3246");
                 break;
             }
 

--- a/components/hub75_matrix_display/matrix_display.cpp
+++ b/components/hub75_matrix_display/matrix_display.cpp
@@ -14,10 +14,13 @@ namespace esphome
         {
             ESP_LOGCONFIG(TAG, "Setting up MatrixDisplay...");
 
-            // The min refresh rate correlates with the update frequency of the component
-            this->mxconfig_.min_refresh_rate = 1000 / update_interval_;
-
-            this->mxconfig_.double_buff = true;
+            // Handle "never" and 0 to avoid divide by 0
+            if (this->update_interval_ == 4294967295 || this->update_interval_ == 0) {
+                // LVGL-driven: pick a constant
+                this->mxconfig_.min_refresh_rate = 120;  // Hz
+            } else {
+                this->mxconfig_.min_refresh_rate = 1000 / this->update_interval_;
+            }
 
             // Display Setup
             dma_display_ = new MatrixPanel_I2S_DMA(this->mxconfig_);
@@ -34,17 +37,17 @@ namespace esphome
          */
         void MatrixDisplay::update()
         {
-            if (this->enabled_)
-            {
+            if (this->enabled_) {
                 // Draw updates to the screen
                 this->do_update_();
-            }
-            else
-            {
+            } else {
                 this->dma_display_->clearScreen();
             }
+
             // Flip buffer to show changes
-            this->dma_display_->flipDMABuffer();
+            if (this->mxconfig_.double_buff) {
+                this->dma_display_->flipDMABuffer();
+            }
         }
 
         void MatrixDisplay::dump_config()
@@ -101,6 +104,54 @@ namespace esphome
 
             // Update pixel value in buffer
             this->dma_display_->drawPixelRGB888(x, y, color.r, color.g, color.b);
+        }
+
+        inline uint8_t expand5to8(uint8_t v) { return (v << 3) | (v >> 2); }
+        inline uint8_t expand6to8(uint8_t v) { return (v << 2) | (v >> 4); }
+
+        void HOT MatrixDisplay::draw_pixels_at(
+            int x_start, int y_start, int w, int h,
+            const uint8_t *ptr,
+            ColorOrder order,
+            ColorBitness bitness,
+            bool big_endian,
+            int x_offset, int y_offset, int x_pad)
+        {
+            if (!this->dma_display_) return;
+
+            const int stride_px = x_offset + w + x_pad;  // LVGL/ESPHome-provided stride.
+
+            for (int yy = 0; yy < h; ++yy) {
+                const int row_base_px = (y_offset + yy) * stride_px + x_offset;
+
+                if (bitness == ColorBitness::COLOR_BITNESS_565) {
+                    // Source is RGB565
+                    const uint16_t *src16 = reinterpret_cast<const uint16_t *>(ptr);
+                    for (int xx = 0; xx < w; ++xx) {
+                        const uint8_t *p = reinterpret_cast<const uint8_t *>(&src16[row_base_px + xx]);
+                        const uint16_t pix565 = big_endian ? (uint16_t(p[0]) << 8) | p[1] : (uint16_t(p[1]) << 8) | p[0];
+
+                        uint8_t r = expand5to8((pix565 >> 11) & 0x1F);
+                        uint8_t g = expand6to8((pix565 >> 5)  & 0x3F);
+                        uint8_t b = expand5to8( pix565        & 0x1F);
+
+                        this->dma_display_->drawPixelRGB888(x_start + xx, y_start + yy, r, g, b);
+                    }
+                } else { // 24-bit (RGB or BGR)
+                    const uint8_t *src24 = ptr + row_base_px * 3;
+                    if (order == ColorOrder::COLOR_ORDER_RGB) {
+                        for (int xx = 0; xx < w; ++xx) {
+                            const uint8_t *p = src24 + xx * 3;
+                            this->dma_display_->drawPixelRGB888(x_start + xx, y_start + yy, p[0], p[1], p[2]);
+                        }
+                    } else { // BGR
+                        for (int xx = 0; xx < w; ++xx) {
+                            const uint8_t *p = src24 + xx * 3;
+                            this->dma_display_->drawPixelRGB888(x_start + xx, y_start + yy, p[2], p[1], p[0]);
+                        }
+                    }
+                }
+            }
         }
 
         void MatrixDisplay::fill(Color color)

--- a/components/hub75_matrix_display/matrix_display.cpp
+++ b/components/hub75_matrix_display/matrix_display.cpp
@@ -26,6 +26,7 @@ namespace esphome
             dma_display_ = new MatrixPanel_I2S_DMA(this->mxconfig_);
             this->dma_display_->begin();
             set_brightness(this->initial_brightness_);
+            this->stored_brightness_ = this->initial_brightness_;
             this->dma_display_->clearScreen();
 
             // Default to off if power switches are present
@@ -37,12 +38,10 @@ namespace esphome
          */
         void MatrixDisplay::update()
         {
-            if (this->enabled_) {
-                // Draw updates to the screen
-                this->do_update_();
-            } else {
-                this->dma_display_->clearScreen();
-            }
+            if (!this->dma_display_) return;
+            if (!this->enabled_) return;
+
+            this->do_update_();
 
             // Flip buffer to show changes
             if (this->mxconfig_.double_buff) {
@@ -92,12 +91,21 @@ namespace esphome
 
         void MatrixDisplay::set_brightness(int brightness)
         {
-            // Wrap brightness function
-            this->dma_display_->setBrightness8(brightness);
+            // Remember last non-zero so power-on can restore without fighting the number entity
+            if (brightness > 0) this->stored_brightness_ = brightness;
+            // Only apply to hardware when enabled; if off, just remember it
+            if (this->enabled_ && this->dma_display_ != nullptr) {
+                this->dma_display_->setBrightness8(brightness);
+                // Latch change & avoid stale flash
+                this->dma_display_->clearScreen();
+            }
         }
 
         void HOT MatrixDisplay::draw_absolute_pixel_internal(int x, int y, Color color)
         {
+            if (!this->dma_display_) return;
+            if (!this->enabled_) return;
+
             // Reject invalid pixels
             if (x >= this->get_width_internal() || x < 0 || y >= this->get_height_internal() || y < 0)
                 return;
@@ -118,6 +126,7 @@ namespace esphome
             int x_offset, int y_offset, int x_pad)
         {
             if (!this->dma_display_) return;
+            if (!this->enabled_) return;
 
             const int stride_px = x_offset + w + x_pad;  // LVGL/ESPHome-provided stride.
 
@@ -156,12 +165,18 @@ namespace esphome
 
         void MatrixDisplay::fill(Color color)
         {
+            if (!this->dma_display_) return;
+            if (!this->enabled_) return;
+
             // Wrap fill screen method
             this->dma_display_->fillScreenRGB888(color.r, color.g, color.b);
         }
 
         void MatrixDisplay::filled_rectangle(int x1, int y1, int width, int height, Color color)
         {
+            if (!this->dma_display_) return;
+            if (!this->enabled_) return;
+
             // Wrap fill rectangle method
             this->dma_display_->fillRect(x1, y1, width, width, color.r, color.g, color.b);
         }

--- a/components/hub75_matrix_display/matrix_display.cpp
+++ b/components/hub75_matrix_display/matrix_display.cpp
@@ -162,19 +162,33 @@ namespace esphome
 
                         this->draw_pixel_rgb888_(x_start + xx, y_start + yy, r, g, b);
                     }
-                } else { // 24-bit (RGB or BGR)
-                    const uint8_t *src24 = ptr + row_base_px * 3;
-                    if (order == ColorOrder::COLOR_ORDER_RGB) {
-                        for (int xx = 0; xx < w; ++xx) {
-                            const uint8_t *p = src24 + xx * 3;
-                            this->draw_pixel_rgb888_(x_start + xx, y_start + yy, p[0], p[1], p[2]);
+                } else if (bitness == ColorBitness::COLOR_BITNESS_888) {
+#if LV_COLOR_DEPTH == 32
+                    // LVGL draw buffer is ARGB8888. Ignore alpha, honor endianness.
+                    const uint8_t *src = ptr + row_base_px * 4;
+
+                    for (int xx = 0; xx < w; ++xx) {
+                        const uint8_t *p = src + xx * 4;
+
+                        uint8_t r, g, b;
+                        if (big_endian) {
+                            // Big endian memory layout: [A][R][G][B]
+                            r = p[1]; g = p[2]; b = p[3];
+                        } else {
+                            // Little endian (ESP32): [B][G][R][A]
+                            r = p[2]; g = p[1]; b = p[0];
                         }
-                    } else { // BGR
-                        for (int xx = 0; xx < w; ++xx) {
-                            const uint8_t *p = src24 + xx * 3;
-                            this->draw_pixel_rgb888_(x_start + xx, y_start + yy, p[2], p[1], p[0]);
-                        }
+
+                        this->draw_pixel_rgb888_(x_start + xx, y_start + yy, r, g, b);
                     }
+#else
+                    // Should never happen with LVGL (no 24bpp mode). If we got here,
+                    // color_bitness reporting is inconsistent with LV_COLOR_DEPTH.
+                    ESP_LOGE(TAG, "Unexpected 888 bitness with LV_COLOR_DEPTH=%d", LV_COLOR_DEPTH);
+#endif
+                } else {
+                    // error, not supported
+                    ESP_LOGE(TAG, "Unexpected bitness=%d with LV_COLOR_DEPTH=%d", bitness, LV_COLOR_DEPTH);
                 }
             }
         }

--- a/components/hub75_matrix_display/matrix_display.cpp
+++ b/components/hub75_matrix_display/matrix_display.cpp
@@ -96,8 +96,6 @@ namespace esphome
             // Only apply to hardware when enabled; if off, just remember it
             if (this->enabled_ && this->dma_display_ != nullptr) {
                 this->dma_display_->setBrightness8(brightness);
-                // Latch change & avoid stale flash
-                this->dma_display_->clearScreen();
             }
         }
 

--- a/components/hub75_matrix_display/matrix_display.cpp
+++ b/components/hub75_matrix_display/matrix_display.cpp
@@ -17,7 +17,7 @@ namespace esphome
             // Handle "never" and 0 to avoid divide by 0
             if (this->update_interval_ == 4294967295 || this->update_interval_ == 0) {
                 // LVGL-driven: pick a constant
-                this->mxconfig_.min_refresh_rate = 120;  // Hz
+                this->mxconfig_.min_refresh_rate = 60;  // Hz
             } else {
                 this->mxconfig_.min_refresh_rate = 1000 / this->update_interval_;
             }

--- a/components/hub75_matrix_display/matrix_display.h
+++ b/components/hub75_matrix_display/matrix_display.h
@@ -9,6 +9,9 @@
 
 #include "ESP32-HUB75-MatrixPanel-I2S-DMA.h"
 
+using esphome::display::ColorBitness;
+using esphome::display::ColorOrder;
+
 namespace esphome
 {
     namespace matrix_display
@@ -56,6 +59,16 @@ namespace esphome
                 this->brightness_values_.push_back(brightness);
                 set_reference(brightness, this);
             };
+
+            /**
+             * Sets the user defined double buffer boolean.
+             *
+             * @param double_buffer double buffer value
+             */
+            void set_double_buffer(bool double_buffer)
+            {
+                this->mxconfig_.double_buff = double_buffer;
+            }
 
             /**
              * Sets the hight of each individual panel.
@@ -257,6 +270,13 @@ namespace esphome
              * @param color Color of the pixel
              */
             void draw_absolute_pixel_internal(int x, int y, Color color) override;
+
+            void draw_pixels_at(int x_start, int y_start, int w, int h,
+                                const uint8_t *ptr,
+                                display::ColorOrder order,
+                                display::ColorBitness bitness,
+                                bool big_endian,
+                                int x_offset, int y_offset, int x_pad) override;
         };
 
     } // namespace matrix_display

--- a/components/hub75_matrix_display/matrix_display.h
+++ b/components/hub75_matrix_display/matrix_display.h
@@ -215,10 +215,8 @@ namespace esphome
                     // restore last non-zero brightness (don’t fight the number entity)
                     int restore = this->stored_brightness_ > 0 ? this->stored_brightness_ : this->initial_brightness_;
                     this->dma_display_->setBrightness8(restore);
-                    this->dma_display_->clearScreen();
                 } else {
                     this->dma_display_->setBrightness8(0);
-                    this->dma_display_->clearScreen();
                 }
             }
 

--- a/components/hub75_matrix_display/matrix_display.h
+++ b/components/hub75_matrix_display/matrix_display.h
@@ -9,6 +9,19 @@
 
 #include "ESP32-HUB75-MatrixPanel-I2S-DMA.h"
 
+// --- VirtualMatrix additions (optional compile-time include) ---
+#ifdef USE_VIRTUAL_PANEL
+  #include "ESP32-HUB75-VirtualMatrixPanel_T.hpp"
+  #ifndef VPANEL_CHAIN
+    #define VPANEL_CHAIN CHAIN_TOP_LEFT_DOWN
+  #endif
+  #ifndef VPANEL_SCAN
+    #define VPANEL_SCAN STANDARD_TWO_SCAN
+  #endif
+  using VPanelType = VirtualMatrixPanel_T<VPANEL_CHAIN, ScanTypeMapping<VPANEL_SCAN>, 1>;
+#endif
+// --- End VirtualMatrix additions ---
+
 using esphome::display::ColorBitness;
 using esphome::display::ColorOrder;
 
@@ -243,9 +256,35 @@ namespace esphome
                 return this->brightness_values_;
             }
 
+            // --- VirtualMatrix additions (runtime toggles) ---
+            void set_virtual_enabled(bool enabled) {
+#ifdef USE_VIRTUAL_PANEL
+                this->use_virtual_panel_ = enabled;
+#endif
+            }
+            void set_virtual_rows(int rows) {
+#ifdef USE_VIRTUAL_PANEL
+                this->v_rows_ = (rows < 1) ? 1 : (rows > 255 ? 255 : rows);
+#endif
+            }
+            void set_virtual_cols(int cols) {
+#ifdef USE_VIRTUAL_PANEL
+                this->v_cols_ = (cols < 1) ? 1 : (cols > 255 ? 255 : cols);
+#endif
+            }
+            // --- End VirtualMatrix additions ---
+
         protected:
             /// @brief Wrapped matrix display
             MatrixPanel_I2S_DMA *dma_display_ = nullptr;
+
+#ifdef USE_VIRTUAL_PANEL
+            /// @brief Optional virtual wrapper (maps virtual coords to physical)
+            VPanelType *virtual_display_ = nullptr;
+            bool use_virtual_panel_ = false;
+            uint8_t v_rows_ = 1;
+            uint8_t v_cols_ = 1;
+#endif
 
             /// @brief Matrix configuration
             HUB75_I2S_CFG mxconfig_;
@@ -267,10 +306,20 @@ namespace esphome
 
             int get_width_internal() override
             {
+#ifdef USE_VIRTUAL_PANEL
+                if (this->use_virtual_panel_) {
+                    return this->mxconfig_.mx_width * static_cast<int>(this->v_cols_);
+                }
+#endif
                 return this->mxconfig_.mx_width * this->mxconfig_.chain_length;
             };
             int get_height_internal() override
             {
+#ifdef USE_VIRTUAL_PANEL
+                if (this->use_virtual_panel_) {
+                    return this->mxconfig_.mx_height * static_cast<int>(this->v_rows_);
+                }
+#endif
                 return this->mxconfig_.mx_height;
             };
 
@@ -289,6 +338,27 @@ namespace esphome
                                 display::ColorBitness bitness,
                                 bool big_endian,
                                 int x_offset, int y_offset, int x_pad) override;
+
+        private:
+            // Route drawing through virtual wrapper when enabled.
+            inline void draw_pixel_rgb888_(int x, int y, uint8_t r, uint8_t g, uint8_t b) {
+#ifdef USE_VIRTUAL_PANEL
+                if (this->use_virtual_panel_ && this->virtual_display_) {
+                    this->virtual_display_->drawPixelRGB888(x, y, r, g, b);
+                    return;
+                }
+#endif
+                this->dma_display_->drawPixelRGB888(x, y, r, g, b);
+            }
+            inline void fill_screen_rgb888_(uint8_t r, uint8_t g, uint8_t b) {
+#ifdef USE_VIRTUAL_PANEL
+                if (this->use_virtual_panel_ && this->virtual_display_) {
+                    this->virtual_display_->fillScreenRGB888(r, g, b);
+                    return;
+                }
+#endif
+                this->dma_display_->fillScreenRGB888(r, g, b);
+            }
         };
 
     } // namespace matrix_display

--- a/components/hub75_matrix_display/matrix_display.h
+++ b/components/hub75_matrix_display/matrix_display.h
@@ -209,6 +209,17 @@ namespace esphome
             void set_state(bool state)
             {
                 this->enabled_ = state;
+
+                if (this->dma_display_ == nullptr) return;
+                if (this->enabled_) {
+                    // restore last non-zero brightness (don’t fight the number entity)
+                    int restore = this->stored_brightness_ > 0 ? this->stored_brightness_ : this->initial_brightness_;
+                    this->dma_display_->setBrightness8(restore);
+                    this->dma_display_->clearScreen();
+                } else {
+                    this->dma_display_->setBrightness8(0);
+                    this->dma_display_->clearScreen();
+                }
             }
 
             /**
@@ -246,6 +257,9 @@ namespace esphome
 
             /// @brief on-off status of the display matrix
             bool enabled_ = false;
+
+            /// @brief last non-zero brightness for restoring after power-on
+            int stored_brightness_ = 128;
 
             /// @brief power switches belonging to this matrix display
             std::vector<matrix_display_switch::MatrixDisplaySwitch *> power_switches_;

--- a/components/hub75_matrix_display/switch/__init__.py
+++ b/components/hub75_matrix_display/switch/__init__.py
@@ -12,9 +12,8 @@ MatrixDisplaySwitch = matrix_display_switch_ns.class_(
     "MatrixDisplaySwitch", switch.Switch, cg.Component
 )
 
-CONFIG_SCHEMA = switch.SWITCH_SCHEMA.extend(
+CONFIG_SCHEMA = switch.switch_schema(MatrixDisplaySwitch).extend(
     {
-        cv.GenerateID(): cv.declare_id(MatrixDisplaySwitch),
         cv.Required(MATRIX_ID): cv.use_id(MatrixDisplay),
     }
 ).extend(cv.COMPONENT_SCHEMA)


### PR DESCRIPTION
This has a few existing PRs baked in to it:
* https://github.com/TillFleisch/ESPHome-HUB75-MatrixDisplayWrapper/pull/40
* https://github.com/TillFleisch/ESPHome-HUB75-MatrixDisplayWrapper/pull/27
* An alternative (simplier) double buffer setting (not based on https://github.com/TillFleisch/ESPHome-HUB75-MatrixDisplayWrapper/pull/18)

This adds:
* Support for LVGL (needs double buffering off as there is no callback available to swap buffers (and LVGL has its own buffer)) with:
``
    double_buffer: false
    auto_clear_enabled: false
    update_interval: never
``
* Adds non-horizontal panel layout support using the virtual matrix template.

I would like to push all of this upstream to ESPHome as a display driver so people can just use it directly without the external component.  Let me know if you have any concerns.  Given the outstanding PRs and lack of updates, if I don't hear anything back I'll proceed with putting together a PR for ESPHome in a couple weeks to get this added.