### PR TITLE
fix(switch): replace deprecated switch.SWITCH_SCHEMA with switch.switch_schema

### DIFF
--- a/components/hub75_matrix_display/switch/__init__.py
+++ b/components/hub75_matrix_display/switch/__init__.py
@@ -12,7 +12,7 @@ MatrixDisplaySwitch = matrix_display_switch_ns.class_(
     "MatrixDisplaySwitch", switch.Switch, cg.Component
 )
 
-CONFIG_SCHEMA = switch.SWITCH_SCHEMA.extend(
+CONFIG_SCHEMA = switch.switch_schema(MatrixDisplaySwitch).extend(
     {
         cv.GenerateID(): cv.declare_id(MatrixDisplaySwitch),
         cv.Required(MATRIX_ID): cv.use_id(MatrixDisplay),


### PR DESCRIPTION
Update the switch platform to use the new schema API to avoid the deprecation warning and upcoming breakage in ESPHome 2025.11.0.

- Replace switch.SWITCH_SCHEMA with switch.switch_schema(MatrixDisplaySwitch)
- Keep existing ID declarations and registration logic unchanged

Reference: https://developers.esphome.io/blog/2025/05/14/_schema-deprecations/

Verified locally with ESPHome 2025.9.0: build succeeds and deprecation warning is gone.